### PR TITLE
feat(brand): auto-theme button from identity-api Manufacturer (v0.0.29)

### DIFF
--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dimo-network/login-with-dimo",
-  "version": "0.0.28",
+  "version": "0.0.29",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/sdk/src/auth/redirectAuth.ts
+++ b/sdk/src/auth/redirectAuth.ts
@@ -89,6 +89,8 @@ export const redirectAuth = (payload: AuthPayload, data: DimoActionPayload) => {
     AuthParam.EntryState,
     AuthParam.ExpirationDate,
     AuthParam.ForceEmail,
+    AuthParam.Icon,
+    AuthParam.Label,
     AuthParam.MessageData,
     AuthParam.Onboarding,
     AuthParam.PermissionTemplateId,

--- a/sdk/src/components/BaseDimoButton.tsx
+++ b/sdk/src/components/BaseDimoButton.tsx
@@ -18,11 +18,23 @@ import {
 } from '@dimo-types/index';
 import { getDimoLoginUrl } from '../utils/url';
 
+/**
+ * Resolved brand passed by each wrapper to BaseDimoButton. `name` drives the
+ * `label` query-param sent to the auth chrome; `logoURI` replaces the
+ * hardcoded DIMO mark inside the button itself. Both are nullable so the
+ * default DIMO chrome renders when no OEM is linked to the dev license.
+ */
+export interface ResolvedBrand {
+  name: string | null;
+  logoURI: string | null;
+}
+
 interface BaseDimoButtonOptions extends BaseButtonProps {
   buttonLabel: (authenticated: boolean) => string;
   entryState: EntryState;
   disableIfAuthenticated?: boolean;
   payload: DimoActionPayload;
+  brand?: ResolvedBrand;
 }
 
 type BaseDimoButtonProps = BaseDimoButtonOptions & LoginButtonProps;
@@ -36,6 +48,7 @@ export const BaseDimoButton: FC<BaseDimoButtonProps> = ({
   disableIfAuthenticated = false,
   altTitle = false,
   payload,
+  brand,
 }) => {
   const { clientId, redirectUri, apiKey, environment, options } =
     getDimoConfig();
@@ -56,6 +69,8 @@ export const BaseDimoButton: FC<BaseDimoButtonProps> = ({
     redirectUri,
     apiKey,
     forceEmail: options?.forceEmail ?? false,
+    icon: brand?.logoURI ?? undefined,
+    label: brand?.name ?? undefined,
   };
 
   const handleButtonClick = () => {
@@ -79,18 +94,26 @@ export const BaseDimoButton: FC<BaseDimoButtonProps> = ({
           disabled={isAuthenticated && disableIfAuthenticated}
           onClick={handleButtonClick}
         >
-          <svg
-            width="20"
-            height="18"
-            viewBox="0 0 20 18"
-            fill="none"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M0 13.0041H11.077C13.4042 13.0041 15.2272 11.2785 15.2272 9.07558C15.2272 6.87266 13.3665 4.99755 11.0787 4.99755H5.4982C4.97342 4.99755 4.54296 5.42387 4.54296 5.9436V11.8169H0V5.75847C0 2.85918 2.3821 0.5 5.30955 0.5H11.3102C16.1019 0.5 20 4.34704 20 9.07388C20 13.8007 16.1825 17.5 11.3102 17.5H0V13.0024V13.0041Z"
-              fill="black"
+          {brand?.logoURI ? (
+            <img
+              className="button-icon"
+              src={brand.logoURI}
+              alt={brand.name ? `${brand.name} logo` : 'OEM logo'}
             />
-          </svg>
+          ) : (
+            <svg
+              width="20"
+              height="18"
+              viewBox="0 0 20 18"
+              fill="none"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M0 13.0041H11.077C13.4042 13.0041 15.2272 11.2785 15.2272 9.07558C15.2272 6.87266 13.3665 4.99755 11.0787 4.99755H5.4982C4.97342 4.99755 4.54296 5.42387 4.54296 5.9436V11.8169H0V5.75847C0 2.85918 2.3821 0.5 5.30955 0.5H11.3102C16.1019 0.5 20 4.34704 20 9.07388C20 13.8007 16.1825 17.5 11.3102 17.5H0V13.0024V13.0041Z"
+                fill="black"
+              />
+            </svg>
+          )}
           <span className="button-label">{buttonLabel(isAuthenticated)}</span>
         </button>
       </div>

--- a/sdk/src/components/ExecuteAdvancedTransactionWithDimo.tsx
+++ b/sdk/src/components/ExecuteAdvancedTransactionWithDimo.tsx
@@ -8,6 +8,7 @@ import {
   ExecuteAdvancedTransactionButtonProps,
   ButtonLabels,
 } from '@dimo-types/index';
+import { useResolvedBrand, formatBrandedLabel } from '@utils/brand';
 
 type ExecuteAdvancedTransactionProps = BaseButtonProps &
   ExecuteAdvancedTransactionButtonProps &
@@ -24,9 +25,10 @@ const ExecuteAdvancedTransactionWithDimo: React.FC<
   abi,
   functionName,
   args,
-  authenticatedLabel = 'Execute Advanced Transaction with Dimo',
-  unAuthenticatedLabel = 'Sign in to Execute Transaction',
+  authenticatedLabel,
+  unAuthenticatedLabel,
   altTitle,
+  brandOverride,
 }) => {
   if (!address || !abi || !functionName || !args) {
     throw new Error('Missing required transaction parameters.');
@@ -39,6 +41,15 @@ const ExecuteAdvancedTransactionWithDimo: React.FC<
     args,
   };
 
+  const brand = useResolvedBrand(brandOverride);
+
+  const resolvedAuthLabel =
+    authenticatedLabel ??
+    formatBrandedLabel('Execute Transaction with {name}', brand.name, 'Execute Advanced Transaction with Dimo');
+  const resolvedUnAuthLabel =
+    unAuthenticatedLabel ??
+    formatBrandedLabel('Sign in to Execute Transaction', brand.name, 'Sign in to Execute Transaction');
+
   return (
     <BaseDimoButton
       mode={mode}
@@ -46,13 +57,14 @@ const ExecuteAdvancedTransactionWithDimo: React.FC<
       onSuccess={onSuccess}
       onError={onError}
       buttonLabel={(authenticated) =>
-        authenticated ? authenticatedLabel : unAuthenticatedLabel
+        authenticated ? resolvedAuthLabel : resolvedUnAuthLabel
       }
       altTitle={altTitle}
       payload={{
         transactionData,
         eventType: EventTypes.EXECUTE_ADVANCED_TRANSACTION,
       }}
+      brand={brand}
     />
   );
 };

--- a/sdk/src/components/LoginWithDimo.tsx
+++ b/sdk/src/components/LoginWithDimo.tsx
@@ -9,6 +9,7 @@ import {
   InternalDimoActionParams,
 } from '@dimo-types/index';
 import { getPermissionsBinary } from '@utils/index';
+import { useResolvedBrand, formatBrandedLabel } from '@utils/brand';
 
 type LoginWithDimoProps = BaseButtonProps & LoginButtonProps & ButtonLabels;
 
@@ -22,11 +23,21 @@ const LoginWithDimo: React.FC<LoginWithDimoProps> = ({
   vehicleMakes,
   onboarding,
   expirationDate,
-  authenticatedLabel = 'Manage DIMO Account',
-  unAuthenticatedLabel = 'Continue with DIMO',
+  authenticatedLabel,
+  unAuthenticatedLabel,
   utm = null,
   altTitle,
+  brandOverride,
 }) => {
+  const brand = useResolvedBrand(brandOverride);
+
+  const resolvedAuthLabel =
+    authenticatedLabel ??
+    formatBrandedLabel('Manage {name} Account', brand.name, 'Manage DIMO Account');
+  const resolvedUnAuthLabel =
+    unAuthenticatedLabel ??
+    formatBrandedLabel('Sign in with {name}', brand.name, 'Continue with DIMO');
+
   const payload: InternalDimoActionParams & { eventType: EventTypes } = {
     ...getPermissionsBinary(permissions, permissionTemplateId),
     vehicles,
@@ -48,11 +59,12 @@ const LoginWithDimo: React.FC<LoginWithDimoProps> = ({
       onSuccess={onSuccess}
       onError={onError}
       buttonLabel={(authenticated) =>
-        authenticated ? authenticatedLabel : unAuthenticatedLabel
+        authenticated ? resolvedAuthLabel : resolvedUnAuthLabel
       }
       disableIfAuthenticated={false}
       altTitle={altTitle}
       payload={payload}
+      brand={brand}
     />
   );
 };

--- a/sdk/src/components/ShareVehiclesWithDimo.tsx
+++ b/sdk/src/components/ShareVehiclesWithDimo.tsx
@@ -8,6 +8,7 @@ import {
   LoginButtonProps,
 } from '@dimo-types/index';
 import { getPermissionsBinary } from '@utils/index';
+import { useResolvedBrand, formatBrandedLabel } from '@utils/brand';
 import { BaseDimoButton } from './BaseDimoButton';
 
 type ShareVehiclesWithDimoProps = BaseButtonProps &
@@ -24,12 +25,22 @@ const ShareVehiclesWithDimo: React.FC<ShareVehiclesWithDimoProps> = ({
   vehicleMakes,
   onboarding,
   expirationDate,
-  authenticatedLabel = 'Share Vehicles with DIMO',
-  unAuthenticatedLabel = 'Sign in to Share Vehicles with DIMO',
+  authenticatedLabel,
+  unAuthenticatedLabel,
   utm = null,
   altTitle,
   powertrainTypes,
+  brandOverride,
 }) => {
+  const brand = useResolvedBrand(brandOverride);
+
+  const resolvedAuthLabel =
+    authenticatedLabel ??
+    formatBrandedLabel('Share Vehicles with {name}', brand.name, 'Share Vehicles with DIMO');
+  const resolvedUnAuthLabel =
+    unAuthenticatedLabel ??
+    formatBrandedLabel('Sign in to Share Vehicles with {name}', brand.name, 'Sign in to Share Vehicles with DIMO');
+
   const payload: InternalDimoActionParams & { eventType: EventTypes } = {
     permissionTemplateId,
     vehicles,
@@ -49,10 +60,11 @@ const ShareVehiclesWithDimo: React.FC<ShareVehiclesWithDimoProps> = ({
       onSuccess={onSuccess}
       onError={onError}
       buttonLabel={(authenticated) =>
-        authenticated ? authenticatedLabel : unAuthenticatedLabel
+        authenticated ? resolvedAuthLabel : resolvedUnAuthLabel
       }
       altTitle={altTitle}
       payload={payload}
+      brand={brand}
     />
   );
 };

--- a/sdk/src/components/SignMessageWithDimo.tsx
+++ b/sdk/src/components/SignMessageWithDimo.tsx
@@ -8,6 +8,7 @@ import {
   SignMessageButtonProps,
   SignMessageData,
 } from '@dimo-types/index';
+import { useResolvedBrand, formatBrandedLabel } from '@utils/brand';
 
 type SignMessageProps = BaseButtonProps & SignMessageButtonProps & ButtonLabels;
 
@@ -43,11 +44,20 @@ const SignMessageWithDimo: React.FC<SignMessageProps> = ({
   onSuccess,
   onError,
   message,
-  authenticatedLabel = 'Sign Message with Dimo',
-  unAuthenticatedLabel = 'Sign in to Sign Message',
+  authenticatedLabel,
+  unAuthenticatedLabel,
   altTitle,
+  brandOverride,
 }) => {
   const messageData = normalizeMessage(message);
+  const brand = useResolvedBrand(brandOverride);
+
+  const resolvedAuthLabel =
+    authenticatedLabel ??
+    formatBrandedLabel('Sign Message with {name}', brand.name, 'Sign Message with Dimo');
+  const resolvedUnAuthLabel =
+    unAuthenticatedLabel ??
+    formatBrandedLabel('Sign in to Sign Message', brand.name, 'Sign in to Sign Message');
 
   return (
     <BaseDimoButton
@@ -56,13 +66,14 @@ const SignMessageWithDimo: React.FC<SignMessageProps> = ({
       onSuccess={onSuccess}
       onError={onError}
       buttonLabel={(authenticated) =>
-        authenticated ? authenticatedLabel : unAuthenticatedLabel
+        authenticated ? resolvedAuthLabel : resolvedUnAuthLabel
       }
       altTitle={altTitle}
       payload={{
         messageData,
         eventType: EventTypes.SIGN_MESSAGE,
       }}
+      brand={brand}
     />
   );
 };

--- a/sdk/src/config/sdkConfig.ts
+++ b/sdk/src/config/sdkConfig.ts
@@ -1,4 +1,5 @@
 import { Environment } from '@enums/index';
+import { fetchManufacturerBrand, ManufacturerBrand } from '@utils/identityApi';
 
 let sdkConfig: {
   clientId: string;
@@ -12,6 +13,64 @@ let sdkConfig: {
   clientId: '',
   redirectUri: '',
 };
+
+/**
+ * Brand metadata resolved from the dev license's linked Manufacturer NFT on
+ * identity-api. Populated asynchronously by `initializeDimoSDK` and cached
+ * here (plus localStorage when available) so subsequent renders read it
+ * synchronously.
+ */
+let sdkBrand: ManufacturerBrand | null = null;
+const brandSubscribers = new Set<() => void>();
+
+const BRAND_STORAGE_KEY = 'dimo.brand.v1';
+const BRAND_STORAGE_TTL_MS = 24 * 60 * 60 * 1000; // 24h — re-fetch daily.
+
+function readBrandFromStorage(clientId: string): ManufacturerBrand | null {
+  if (typeof window === 'undefined' || !window.localStorage) return null;
+  try {
+    const raw = window.localStorage.getItem(BRAND_STORAGE_KEY);
+    if (!raw) return null;
+    const cached = JSON.parse(raw) as { clientId: string; cachedAt: number; brand: ManufacturerBrand };
+    if (cached.clientId.toLowerCase() !== clientId.toLowerCase()) return null;
+    if (Date.now() - cached.cachedAt > BRAND_STORAGE_TTL_MS) return null;
+    return cached.brand;
+  } catch {
+    return null;
+  }
+}
+
+function writeBrandToStorage(clientId: string, brand: ManufacturerBrand): void {
+  if (typeof window === 'undefined' || !window.localStorage) return;
+  try {
+    window.localStorage.setItem(BRAND_STORAGE_KEY, JSON.stringify({
+      clientId, cachedAt: Date.now(), brand,
+    }));
+  } catch { /* quota / private mode — ignore */ }
+}
+
+function setBrand(b: ManufacturerBrand | null): void {
+  sdkBrand = b;
+  brandSubscribers.forEach((cb) => cb());
+}
+
+/**
+ * Internal: kicks off a brand fetch. Fire-and-forget — failures leave brand
+ * null and the button keeps its default DIMO chrome.
+ */
+function loadBrand(clientId: string, environment: Environment): void {
+  // Seed from localStorage first so the first render is already branded
+  // (avoids a flash of DIMO before the network round-trip resolves).
+  const cached = readBrandFromStorage(clientId);
+  if (cached) setBrand(cached);
+
+  // Then revalidate from identity-api in the background.
+  fetchManufacturerBrand(clientId, environment).then((fresh) => {
+    if (!fresh) return;
+    setBrand(fresh);
+    writeBrandToStorage(clientId, fresh);
+  }).catch(() => { /* swallowed — already typed as null */ });
+}
 
 export const initializeDimoSDK = ({
   clientId,
@@ -29,6 +88,7 @@ export const initializeDimoSDK = ({
   };
 }) => {
   sdkConfig = { clientId, redirectUri, apiKey, environment, options };
+  loadBrand(clientId, environment);
 };
 
 export const getDimoConfig = () => {
@@ -38,4 +98,17 @@ export const getDimoConfig = () => {
     );
   }
   return sdkConfig;
+};
+
+/** Returns the cached brand for the configured dev license, or null. */
+export const getBrand = (): ManufacturerBrand | null => sdkBrand;
+
+/**
+ * Internal: subscribe to brand-state changes. Used by `useDimoAuthBrand` via
+ * `useSyncExternalStore` to re-render components when the async fetch
+ * resolves after init.
+ */
+export const subscribeBrand = (callback: () => void): (() => void) => {
+  brandSubscribers.add(callback);
+  return () => brandSubscribers.delete(callback);
 };

--- a/sdk/src/enums/auth.enums.ts
+++ b/sdk/src/enums/auth.enums.ts
@@ -16,6 +16,8 @@ export enum AuthParam {
   EntryState = 'entryState',
   ExpirationDate = 'expirationDate',
   ForceEmail = 'forceEmail',
+  Icon = 'icon',
+  Label = 'label',
   MessageData = 'messageData',
   Onboarding = 'onboarding',
   PermissionTemplateId = 'permissionTemplateId',

--- a/sdk/src/hooks/useDimoAuthBrand.ts
+++ b/sdk/src/hooks/useDimoAuthBrand.ts
@@ -1,0 +1,21 @@
+import { useSyncExternalStore } from 'react';
+import { getBrand, subscribeBrand } from '../config/sdkConfig';
+import type { ManufacturerBrand } from '@utils/identityApi';
+
+/**
+ * Returns the OEM brand metadata (name + resolved logo URL) for the dev
+ * license configured via `initializeDimoSDK`. Re-renders when the async
+ * fetch resolves.
+ *
+ * Returns `null` until the fetch completes, or if the dev license has no
+ * linked manufacturer (or the fetch fails). Consumers should fall back to
+ * their default UI when this is `null`.
+ */
+export function useDimoAuthBrand(): ManufacturerBrand | null {
+  return useSyncExternalStore(
+    subscribeBrand,
+    getBrand,
+    // SSR snapshot — no brand is known before hydration.
+    () => null
+  );
+}

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -6,12 +6,17 @@ export { default as SignMessageWithDimo } from './components/SignMessageWithDimo
 export { default as LogoutWithDimo } from './components/LogoutWithDimo';
 
 // Export config initialization
-export { initializeDimoSDK, getDimoConfig } from './config/sdkConfig';
+export { initializeDimoSDK, getDimoConfig, getBrand } from './config/sdkConfig';
 
 export {
   useDimoAuthState,
   DimoAuthProvider,
 } from './auth/context/DimoAuthContext';
+
+// Brand hook + types (auto-themes the button from identity-api).
+export { useDimoAuthBrand } from './hooks/useDimoAuthBrand';
+export type { ManufacturerBrand } from './utils/identityApi';
+export type { BrandOverride } from './types/ui.types';
 
 // Export enums
 export { EntryState, DimoSDKModes, Permissions } from '@enums/index';

--- a/sdk/src/types/auth.types.ts
+++ b/sdk/src/types/auth.types.ts
@@ -16,6 +16,10 @@ export interface BaseAuthParams {
   redirectUri?: string;
   apiKey?: string;
   altTitle?: boolean;
+  /** OEM logo URL passed to the auth popup/redirect for brand-aware chrome. */
+  icon?: string;
+  /** OEM brand name used in popup/redirect copy (e.g. "Toyota"). */
+  label?: string;
 }
 
 export interface AuthPayload extends BaseAuthParams, EventHandlers {}

--- a/sdk/src/types/ui.types.ts
+++ b/sdk/src/types/ui.types.ts
@@ -6,12 +6,26 @@ export interface ButtonLabels {
   unAuthenticatedLabel?: string;
 }
 
+/**
+ * Per-call override for the brand the button renders. Wins over the brand
+ * fetched at init time from identity-api. Both fields are optional — pass
+ * only what you want to override (e.g. just `logoURI`, or just `name`).
+ *
+ * `logoURI` accepts an `ipfs://Qm…` URI or any https URL; the SDK resolves
+ * ipfs URIs to the DIMO HTTP gateway internally.
+ */
+export interface BrandOverride {
+  name?: string;
+  logoURI?: string;
+}
+
 export interface BaseButtonProps extends DimoActionParams {
   mode: DimoSDKModes;
   altTitle?: boolean;
   onSuccess: (authData: AuthData) => void;
   onError: (error: Error) => void;
   labels?: ButtonLabels;
+  brandOverride?: BrandOverride;
 }
 
 export type LoginButtonProps = DimoActionParams;

--- a/sdk/src/utils/brand.ts
+++ b/sdk/src/utils/brand.ts
@@ -1,0 +1,48 @@
+import { useDimoAuthBrand } from '@hooks/useDimoAuthBrand';
+import { resolveImageURI } from './identityApi';
+import type { BrandOverride } from '@dimo-types/index';
+import type { ResolvedBrand } from '@components/BaseDimoButton';
+
+/**
+ * Merges the per-call `brandOverride` prop with the brand fetched at SDK
+ * init and produces the ResolvedBrand shape that BaseDimoButton + the
+ * popup/redirect URL payload consume.
+ *
+ * Resolution rules:
+ *   - `brandOverride.name`     wins over fetched `name`.
+ *   - `brandOverride.logoURI`  wins over fetched `logoURI`. ipfs:// is
+ *                              resolved to the DIMO HTTP gateway here so
+ *                              consumers can drop either scheme into the
+ *                              prop.
+ *   - Anything not overridden falls back to the init-time brand, or null
+ *     if no brand could be fetched (or the dev license has no manufacturer
+ *     linkage yet).
+ */
+export function useResolvedBrand(override?: BrandOverride): ResolvedBrand {
+  const fetched = useDimoAuthBrand();
+
+  const name = override?.name ?? fetched?.name ?? null;
+  const overrideLogo = override?.logoURI ? resolveImageURI(override.logoURI) : null;
+  const logoURI = overrideLogo ?? fetched?.logoURI ?? null;
+
+  return { name, logoURI };
+}
+
+/**
+ * Helper for label templates. Substitutes `{name}` placeholder when a brand
+ * name is available; otherwise returns the SDK default verbatim.
+ *
+ *   formatBrandedLabel('Sign in with {name}', 'Toyota', 'Continue with DIMO')
+ *   // → 'Sign in with Toyota'
+ *
+ *   formatBrandedLabel('Sign in with {name}', null, 'Continue with DIMO')
+ *   // → 'Continue with DIMO'
+ */
+export function formatBrandedLabel(
+  template: string,
+  brandName: string | null,
+  fallback: string
+): string {
+  if (!brandName) return fallback;
+  return template.replace(/\{name\}/g, brandName);
+}

--- a/sdk/src/utils/eventHandler.ts
+++ b/sdk/src/utils/eventHandler.ts
@@ -148,6 +148,8 @@ export const createMessageHandler = (
     entryState,
     forceEmail,
     altTitle,
+    icon,
+    label,
   } = basePayload;
 
   const { target, origin, mode } = config;
@@ -168,6 +170,8 @@ export const createMessageHandler = (
         entryState,
         forceEmail,
         eventType: MessageEventType.AUTH_INIT,
+        ...(icon  && { icon }),
+        ...(label && { label }),
         ...(mode === DimoSDKModes.POPUP && { altTitle }),
       };
       sendMessageToTarget(target, initialMessage, origin, onError);

--- a/sdk/src/utils/identityApi.ts
+++ b/sdk/src/utils/identityApi.ts
@@ -1,0 +1,90 @@
+/**
+ * Minimal identity-api client used to resolve OEM brand metadata from a
+ * dev license clientId.
+ *
+ * - Reads `Manufacturer.imageURI` and `Manufacturer.name` filtered by the
+ *   `devLicenseClientId` on-chain attribute.
+ * - Resolves `ipfs://Qm…` to the DIMO IPFS HTTP gateway so an `<img>` element
+ *   can render it directly.
+ * - Swallows every error and returns `null`. The button must always render
+ *   regardless of network conditions.
+ */
+
+import { Environment } from '@enums/index';
+
+export interface ManufacturerBrand {
+  /** Manufacturer name from on-chain (e.g. "Toyota"). */
+  name: string;
+  /** HTTPS-resolved logo URL ready to drop into an <img> src. */
+  logoURI: string | null;
+}
+
+const IDENTITY_API_URLS: Record<Environment, string> = {
+  [Environment.LOCAL]:       'http://localhost:8080/query',
+  [Environment.DEVELOPMENT]: 'https://identity-api.dev.dimo.zone/query',
+  [Environment.PRODUCTION]:  'https://identity-api.dimo.zone/query',
+};
+
+const IPFS_GATEWAY = 'https://assets.dimo.org/ipfs';
+
+/** GraphQL query: lookup a manufacturer by its associated dev license clientId. */
+const BRAND_QUERY = `
+  query BrandByDevLicense($clientId: Address!) {
+    manufacturer(by: { devLicenseClientId: $clientId }) {
+      name
+      imageURI
+    }
+  }
+`.replace(/\s+/g, ' ').trim();
+
+/**
+ * Resolve an `imageURI` value to a URL that an <img> tag can load.
+ *   ipfs://Qm…  → https://assets.dimo.org/ipfs/Qm…
+ *   https://…   → returned as-is
+ *   anything else (incl. null/empty) → null
+ */
+export function resolveImageURI(imageURI: string | null | undefined): string | null {
+  if (!imageURI) return null;
+  if (imageURI.startsWith('ipfs://')) {
+    return `${IPFS_GATEWAY}/${imageURI.slice('ipfs://'.length)}`;
+  }
+  if (imageURI.startsWith('https://') || imageURI.startsWith('http://')) {
+    return imageURI;
+  }
+  return null;
+}
+
+/**
+ * One-shot brand lookup. Resolves to `null` on any failure — the button
+ * silently keeps its default DIMO branding rather than blocking auth.
+ */
+export async function fetchManufacturerBrand(
+  clientId: string,
+  environment: Environment = Environment.PRODUCTION
+): Promise<ManufacturerBrand | null> {
+  if (!clientId) return null;
+  const url = IDENTITY_API_URLS[environment] ?? IDENTITY_API_URLS[Environment.PRODUCTION];
+
+  try {
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        query: BRAND_QUERY,
+        variables: { clientId },
+      }),
+    });
+    if (!response.ok) return null;
+    const body = await response.json() as {
+      data?: { manufacturer?: { name?: string; imageURI?: string | null } | null };
+    };
+    const mfr = body.data?.manufacturer;
+    if (!mfr?.name) return null;
+    return {
+      name: mfr.name,
+      logoURI: resolveImageURI(mfr.imageURI),
+    };
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary

The SDK now fetches OEM brand metadata at `initializeDimoSDK` time and auto-themes every button component. Zero consumer config: dropping in the SDK with a clientId whose dev license is linked to a Manufacturer NFT renders the OEM logo + a `"Sign in with {name}"` label automatically.

Pairs with [`DIMO-Network/identity-api#184`](https://github.com/DIMO-Network/identity-api/pull/184) which adds the `Manufacturer.imageURI` + `Manufacturer.devLicenseClientId` indexer.

## Resolution flow

```
initializeDimoSDK({ clientId, environment })
       │
       ├─ writes module-level config (sync)
       └─ fires fetchManufacturerBrand(clientId, env)  ← fire-and-forget
                       │
                       ▼
            POST identity-api /query
              manufacturer(by:{ devLicenseClientId: $clientId }) {
                name
                imageURI
              }
                       │
                       ▼
            cache { name, logoURI } in module state + localStorage (24h TTL)

useDimoAuthBrand()           ← React hook over module state
       │
       ▼
<LoginWithDimo>              ← renders OEM <img> + "Sign in with {name}"
<SignMessageWithDimo>        ← "Sign Message with {name}"
<ShareVehiclesWithDimo>      ← "Share Vehicles with {name}"
<ExecuteAdvancedTransactionWithDimo>
                             ← brand-override prop wins; explicit labels win.
                             ← icon + label propagate to popup AUTH_INIT
                               and redirect URL params (consumed by Slice C).
```

## New files

- `src/utils/identityApi.ts` — minimal `fetchManufacturerBrand` + `resolveImageURI` (`ipfs://` → `https://assets.dimo.org/ipfs/…`)
- `src/hooks/useDimoAuthBrand.ts` — `useSyncExternalStore` over module state
- `src/utils/brand.ts` — `useResolvedBrand(brandOverride)` + `formatBrandedLabel(template, name, fallback)`

## Modified files

| File | Change |
|---|---|
| `src/config/sdkConfig.ts` | Async brand fetch on init; localStorage cache (24h TTL); `getBrand` + `subscribeBrand` exports |
| `src/components/BaseDimoButton.tsx` | Render `<img class="button-icon">` when `brand.logoURI` set, fall back to hardcoded DIMO SVG. Threads `icon` + `label` into the `AuthPayload`. |
| `src/components/{Login,SignMessage,ShareVehicles,ExecuteAdvancedTransaction}WithDimo.tsx` | Each wrapper merges `brandOverride` prop with fetched brand, computes labels via a `{name}`-substituting template, falls back to today's DIMO defaults when no brand is linked. |
| `src/auth/redirectAuth.ts` | Appends `?icon=&label=` to the URL via `AuthParam.Icon` / `AuthParam.Label`. |
| `src/utils/eventHandler.ts` | Includes `icon` + `label` in the popup's `AUTH_INIT` postMessage (only when set, so the popup payload stays unchanged for un-linked dev licenses). |
| `src/enums/auth.enums.ts` | `AuthParam.Icon`, `AuthParam.Label` |
| `src/types/ui.types.ts` | New `BrandOverride { name?; logoURI? }`; added `brandOverride?` to `BaseButtonProps` |
| `src/types/auth.types.ts` | `BaseAuthParams.icon`, `BaseAuthParams.label` (optional) |
| `src/index.ts` | Re-exports `useDimoAuthBrand`, `getBrand`, `ManufacturerBrand`, `BrandOverride` |
| `package.json` | 0.0.28 → 0.0.29 |

## Backward compatibility

Every change is purely additive. Behaviour is unchanged when:
- The dev license has no `Manufacturer.devLicenseClientId` link on-chain yet (the brand fetch returns `null`)
- identity-api is unreachable (errors are swallowed, brand stays `null`)
- A consumer passes explicit `authenticatedLabel` / `unAuthenticatedLabel` (they always win over brand-derived defaults)
- A consumer passes a `brandOverride` prop (it overrides anything fetched)

Existing apps on the previous SDK version see today's UI (DIMO mark + "Continue with DIMO" / "Sign Message with Dimo") with no code change required.

## Consumer override surface

```tsx
<LoginWithDimo
  mode="popup"
  onSuccess={...}
  onError={...}
  // both optional, both ergonomic — accepts ipfs:// or https://
  brandOverride={{ name: 'Lexus', logoURI: 'ipfs://Qm…' }}
  // explicit labels still win, as before
  authenticatedLabel="Manage your Toyota"
/>
```

## Headless API

For consumers building their own button:

```tsx
import { useDimoAuthBrand } from '@dimo-network/login-with-dimo';

const brand = useDimoAuthBrand();  // { name, logoURI } | null
```

## Out of scope (separate PRs)

- Popup chrome reading `icon` + `label` to render branded popup header — the SDK already sends them via both URL and `AUTH_INIT`, but the popup page must be updated to read them (Slice C).
- Brand record schema beyond `{ name, logoURI }` (e.g. `primaryColor`, `signInLabel`) — handle via per-component `brandOverride` for now; reconsider once Slice C lands.

## Test plan

- [ ] Visual: load demo with toyota dev license clientId, button shows Toyota mark + "Sign in with Toyota"
- [ ] Visual: clear localStorage, first paint is DIMO mark (no flash), then Toyota mark resolves
- [ ] Visual: subsequent loads paint Toyota mark immediately from cache
- [ ] Functional: `brandOverride` prop overrides fetched brand
- [ ] Functional: explicit `authenticatedLabel` wins over brand template
- [ ] Functional: pass an `ipfs://Qm…` logoURI in `brandOverride` → gateway-resolved in DOM
- [ ] Network: simulate identity-api 500 → button keeps DIMO default chrome
- [ ] No regression: dev licenses with no Manufacturer link still render DIMO chrome